### PR TITLE
Bump dependencies, clean up `ito` functions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,18 +8,25 @@ readme = "README.md"
 repository = "https://github.com/amosborne/worstcase"
 
 [tool.poetry.dependencies]
-python = "^3.9"
-networkx = "^2.5.1"
-pyDOE = "^0.3.8"
-Pint = "^0.20"
+python = "^3.10"
+Pint = "^0.24.4"
+networkx = "^3.3"
+pyDOE = "^1.0.2"
 
 [tool.poetry.group.dev.dependencies]
-pre-commit = "^2.12.1"
-isort = "^5.8.0"
+pre-commit = "^4.6.0"
+isort = "^8.0.0"
 black = "^22"
-flake9 = "^3.8.3"
-pytest-randomly = "^3.8.0"
-pytest-cov = "^2.12.0"
+flake8 = "^7.3.0"
+flake8-pyproject = "^1.2.4"
+pytest = "^9.0.3"
+pytest-randomly = "^4.1.0"
+pytest-cov = "^7.1.0"
+
+[tool.poetry.group.examples]
+optional = true
+
+[tool.poetry.group.examples.dependencies]
 jupyterlab = "^3.0.15"
 matplotlib = "^3.4.2"
 jupyterlab-code-formatter = "^1.5.3"
@@ -31,7 +38,7 @@ multi_line_output = 3
 [tool.flake8]
 max-line-length = 88
 extend-ignore = "E203"
-exclude = "*.ipynb_checkpoints*"
+extend-exclude = "*.ipynb_checkpoints*,.venv,dist"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/tests/test_worstcase.py
+++ b/tests/test_worstcase.py
@@ -27,9 +27,26 @@ def test_param_units():
     assert p.ito(unit("C/s")).nom.m == 1
 
 
+def test_param_pint():
+    p = param.bytol(1 * unit.feet / unit.hour, 0.1, True)
+    assert p.nom.u == unit.feet / unit.hour
+    assert p.nom.u == p.lb.u == p.ub.u
+    p.ito(unit.miles / unit.second)
+    assert p.nom.u == unit.mile / unit.second
+    assert p.nom.u == p.lb.u == p.ub.u
+    p.ito_base_units()
+    assert p.nom.u == unit.meter / unit.second
+    assert p.nom.u == p.lb.u == p.ub.u
+
+
 def test_param_outoforder():
     with pytest.raises(AssertionError):
         param.byrange(0, 1, 1)
+
+
+def test_param_different_units():
+    with pytest.raises(AssertionError):
+        param.byrange(1 * unit.second, 0.8 * unit.ms, 2 * unit.hour)
 
 
 def test_derive_byev():

--- a/worstcase/worstcase.py
+++ b/worstcase/worstcase.py
@@ -72,29 +72,28 @@ class Parameter(AbstractParameter):
         ub = ("{ub:" + pretty + "} (ub)").format(ub=self.ub.to_compact())
         return tag + nom + lb + ub
 
-    def ito(self, other=None, *contexts, **ctx_kwargs):
-        self.lb.ito(other, *contexts, **ctx_kwargs)
-        self.nom.ito(other, *contexts, **ctx_kwargs)
-        self.ub.ito(other, *contexts, **ctx_kwargs)
+    def apply(self, funcname, *args, **kwargs):
+        """Apply a function to nominal and upper/lower bound values.
+
+        Ex. `self.apply(ito_base_units)` will convert all values to base units
+            if using Pint values.
+        """
+        getattr(self.nom, funcname)(*args, **kwargs)
+        getattr(self.lb, funcname)(*args, **kwargs)
+        getattr(self.ub, funcname)(*args, **kwargs)
         return self
+
+    def ito(self, other=None, *contexts, **ctx_kwargs):
+        return self.apply("ito", other, *contexts, **ctx_kwargs)
 
     def ito_base_units(self):
-        self.lb.ito_base_units()
-        self.nom.ito_base_units()
-        self.ub.ito_base_units()
-        return self
+        return self.apply("ito_base_units")
 
     def ito_reduced_units(self):
-        self.lb.ito_reduced_units()
-        self.nom.ito_reduced_units()
-        self.ub.ito_reduced_units()
-        return self
+        return self.apply("ito_reduced_units")
 
     def ito_root_units(self):
-        self.lb.ito_root_units()
-        self.nom.ito_root_units()
-        self.ub.ito_root_units()
-        return self
+        return self.apply("ito_root_units")
 
     def graph(self):
         graph = nx.DiGraph()

--- a/worstcase/worstcase.py
+++ b/worstcase/worstcase.py
@@ -7,7 +7,7 @@ from warnings import warn
 import networkx as nx
 import numpy as np
 from pint import Quantity, UnitRegistry
-from pyDOE import lhs
+from pydoe import lhs
 
 Unit = UnitRegistry()
 


### PR DESCRIPTION
Cleaning up some issues I had starting a new development environment. This drops support for the EoL'ed Python 3.9 to allow for an agreeable Python version between `worstcase` and some other analysis packages (`handcalcs`). It also bumps most dependencies to a more modern version. Dependencies that are only needed for the example `ipynb` are moved to a separate dependency group for cleanliness (and because `jupyterlab` was not cooperating with my windows install). 

The `ito` changes are unrelated to the dependency changes, it was just something quick I needed for future development. Functionality of the class methods are the same but now you can use `apply` generically in your own programs. 