### PR TITLE
feat: add LaTeX pretty formatting

### DIFF
--- a/tests/test_worstcase.py
+++ b/tests/test_worstcase.py
@@ -5,20 +5,23 @@ from worstcase import derive, param, unit
 
 def test_param_byrange():
     p = param.byrange(1.23456, 1, 2, tag="test_byrange", sigfig=3)
-    assert str(p) == "test_byrange: 1.23 (nom), 1 (lb), 2 (ub)"
     assert p.nom == 1.23456 and p.lb == 1 and p.ub == 2
+    assert str(p) == "test_byrange: 1.23 (nom), 1 (lb), 2 (ub)"
+    assert f"{p:L}" == "$1.23 \\,{}^{+0.765}_{-0.235}$"
 
 
 def test_param_bytol_absolute():
     p = param.bytol(1, 0.123, False, tag="test_bytol_absolute", sigfig=2)
-    assert str(p) == "test_bytol_absolute: 1 (nom), 0.88 (lb), 1.1 (ub)"
     assert p.nom == 1 and p.lb == 0.877 and p.ub == 1.123
+    assert str(p) == "test_bytol_absolute: 1 (nom), 0.88 (lb), 1.1 (ub)"
+    assert f"{p:L}" == "$1 \\pm 0.12$"
 
 
 def test_param_bytol_relative():
     p = param.bytol(2, 0.16, True, sigfig=2)
-    assert str(p) == "2 (nom), 1.7 (lb), 2.3 (ub)"
     assert p.nom == 2 and p.lb == 1.68 and p.ub == 2.32
+    assert str(p) == "2 (nom), 1.7 (lb), 2.3 (ub)"
+    assert f"{p:L}" == "$2 \\pm 0.32$"
 
 
 def test_param_units():
@@ -59,6 +62,8 @@ def test_derive_byev():
     assert C.derivation.nom == {A: A.nom, B: B.nom}
     assert C.derivation.lb == {A: A.lb, B: B.lb}
     assert C.derivation.ub == {A: A.ub, B: B.ub}
+    assert str(C) == "C: 7 (nom), 1.9 (lb), 12.1 (ub)"
+    assert f"{C:L}" == "$7 \\pm 5.1$"
 
 
 def test_derive_bymc():

--- a/worstcase/worstcase.py
+++ b/worstcase/worstcase.py
@@ -64,13 +64,39 @@ class Parameter(AbstractParameter):
         tol = nom * tol if rel else tol
         return Parameter(nom, nom - tol, nom + tol, tag, sigfig)
 
+    def formatter_string(self):
+        """Generate the formatter string for the current data"""
+        return "0.{sigfig}G#~P".format(sigfig=self.sigfig)
+
     def __repr__(self):
-        pretty = "0.{sigfig}G~P".format(sigfig=self.sigfig)
+        pretty = self.formatter_string()
         tag = "{tag}: ".format(tag=self.tag) if self.tag else ""
-        nom = ("{nom:" + pretty + "} (nom), ").format(nom=self.nom.to_compact())
-        lb = ("{lb:" + pretty + "} (lb), ").format(lb=self.lb.to_compact())
-        ub = ("{ub:" + pretty + "} (ub)").format(ub=self.ub.to_compact())
+        nom = ("{nom:" + pretty + "} (nom), ").format(nom=self.nom)
+        lb = ("{lb:" + pretty + "} (lb), ").format(lb=self.lb)
+        ub = ("{ub:" + pretty + "} (ub)").format(ub=self.ub)
+
         return tag + nom + lb + ub
+
+    def _repr_latex_(self):
+        upper_deviation = self.ub - self.nom
+        lower_deviation = self.nom - self.lb
+        pretty = self.formatter_string()
+        if f"{upper_deviation:{pretty}}" == f"{lower_deviation:{pretty}}":
+            return f"${self.nom:{pretty}} \\pm {upper_deviation:{pretty}}$"
+        else:
+            return (
+                f"${self.nom:{pretty}} \\,{{}}"
+                f"^{{+{upper_deviation:{pretty}}}}"
+                f"_{{-{lower_deviation:{pretty}}}}$"
+            )
+
+    def __format__(self, fmt_spec):
+        if not fmt_spec:
+            return str(self)
+        if fmt_spec == "L":
+            return self._repr_latex_()
+        else:
+            raise ValueError("Invalid format specifier")
 
     def apply(self, funcname, *args, **kwargs):
         """Apply a function to nominal and upper/lower bound values.
@@ -158,6 +184,12 @@ class Derivative(AbstractParameter):
 
     def __repr__(self):
         return self.derive().__repr__()
+
+    def _repr_latex_(self):
+        return self.derive()._repr_latex_()
+
+    def __format__(self, format_spec):
+        return self.derive().__format__(format_spec)
 
     def __call__(self, *args, tag=None, sigfig=None, n=None, **kwargs):
 


### PR DESCRIPTION
Add $\LaTeX$ pretty formatting to `Parameter`. This feature can be accessed either by using the `L` format specifier (similar to how Pint does it) or via `_repr_latex_` which is a psudo-standard function used by `nbconvert` and some other packages. When using VSCode with the Jupyter extension + `handcalcs`, for example, values will automatically be rendered in $\LaTeX$ to match other computations:

<img width="578" height="168" alt="image" src="https://github.com/user-attachments/assets/2d9707eb-8ab1-49a8-baf6-b9f899de64d9" />
